### PR TITLE
Cleanup Dead/Redundant Code

### DIFF
--- a/UIInfoSuite2/Compatibility/ILevelExtender.cs
+++ b/UIInfoSuite2/Compatibility/ILevelExtender.cs
@@ -1,7 +1,0 @@
-﻿namespace UIInfoSuite2.Compatibility;
-
-public interface ILevelExtender
-{
-  int[] CurrentXP();
-  int[] RequiredXP();
-}


### PR DESCRIPTION
- Remove dead ILevelExtender interface

Some issues have already been done or are not applicable/redundant in this rework.
Closing them for cleanup.

#76 Folder moves are N/A. However, this commit also introduces [HudMessagePatch.cs](https://github.com/dazuki/UIInfoSuite2Alt/blob/60a8fded/UIInfoSuite2Alt/Patches/HudMessagePatch.cs) (dazuki/UIInfoSuite2Alt@60a8fded)

Harmony patch that shifts HUD notifications (Achievement unlocked, Drops pickup) upward when SpaceCore adds extra experience bars, preventing overlap. Not closing since this patch could be useful for SpaceCore if/when support is added but i leave it up to you if this feels useful for rework.

Closes #69
Closes #64
Closes #63
Closes #66
Closes #62
Closes #221
Closes #112
Closes #142
Closes #164
Closes #228